### PR TITLE
Fixed call to afpacket.NewPacketSource

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -147,7 +147,7 @@ func startPacketScanEngine(ctx context.Context, conf *packetScanConfig) error {
 	r := conf.scanRange
 
 	// setup network interface to read/write packets
-	ps, err := afpacket.NewPacketSource(r.Interface.Name, conf.vpnMode)
+	ps, err := afpacket.NewPacketSource(r.Interface.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
afpacket.NewPacketSource now only takes an interface name.