### PR TITLE
afpacket: fix NewPacketSource params GOOS!=linux

### DIFF
--- a/pkg/packet/afpacket/readwriter_other.go
+++ b/pkg/packet/afpacket/readwriter_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package afpacket
@@ -16,7 +17,7 @@ type Source struct{}
 // Assert that AfPacketSource conforms to the packet.ReadWriter interface
 var _ packet.ReadWriter = (*Source)(nil)
 
-func NewPacketSource(iface string) (*Source, error) {
+func NewPacketSource(iface string, vpnMode bool) (*Source, error) {
 	return nil, ErrOS
 }
 


### PR DESCRIPTION
The signature of `afpacket.NewPacketSource` was updated in `readwriter.go` (`29ca59d5`) for `GOOS=linux`, but the signature for that same function in `readwriter_other.go` for `GOOS!=linux` was not updated to match. This causes a build failure when `GOOS!=linux`. The build failure is not critical since only `GOOS=linux` is supported .