### PR TITLE
ci(release): keep 0.x bumps for breaking changes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -17,6 +17,7 @@ trim = true
 
 [bump]
 initial_tag = "v0.1.0"
+breaking_always_bump_major = false
 
 [git]
 conventional_commits = true


### PR DESCRIPTION
  ## Summary
  - Set git-cliff bump behavior so breaking changes stay on the 0.x line instead of jumping to 1.0.0.
  - This makes `preview-release` and the release helper compute `v0.6.0` for the current history.

  ## Validation
  - `git cliff --config cliff.toml --bumped-version` -> `v0.6.0`
  - `python3 .github/scripts/compute_release_version.py --release-kind stable` -> `v0.6.0`
  - `python3 .github/scripts/compute_release_version.py --release-kind rc` -> `v0.6.0-rc.1`