### PR TITLE
ci: gate Go jobs on relevant paths and document ENOBUFS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,28 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go_ci: ${{ steps.filter.outputs.go_ci }}
+
+    steps:
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            go_ci:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.golangci.yml'
+              - '.github/workflows/**'
+              - '.github/scripts/**'
+
   go:
+    needs: changes
+    if: needs.changes.outputs.go_ci == 'true'
     runs-on: ubuntu-latest
     container: golang:1.25-alpine
     env:
@@ -61,6 +82,8 @@ jobs:
         run: go build -ldflags "-w -s"
 
   go-macos:
+    needs: changes
+    if: needs.changes.outputs.go_ci == 'true'
     name: go (macOS ${{ matrix.goarch }})
     runs-on: ${{ matrix.runner }}
     env:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ sample output:
 
 In this case we find out that ports 22 and 443 are open.
 
+If you see `send: No buffer space available` during large scans, it usually means the sender is outrunning the kernel/raw-socket buffers.
+The first fix is to add `--rate` and lower the send burst, for example `-r 100000/s` or lower if needed.
+On some systems, tuning OS socket/buffer limits can also help, but rate limiting is the primary fix.
+
 scan with JSON output:
 
 ```


### PR DESCRIPTION
  ## Summary
  - Add a `paths-filter` gate so Go CI jobs only run for relevant Go, module, lint, or CI/script changes.
  - Document the `send: No buffer space available` failure mode and point users to `--rate` as the primary
  mitigation.