### PR TITLE
fix(ci): checkout before filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       go_ci: ${{ steps.filter.outputs.go_ci }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@v4


### PR DESCRIPTION
  ## Summary
  - Add `actions/checkout` before `dorny/paths-filter` in the CI change-detection job so the filter can
  inspect git history on `master`.