### PR TITLE
fix(ci): install git-cliff for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           fetch-depth: 100
           fetch-tags: true
 
+      - name: Install git-cliff
+        uses: taiki-e/install-action@git-cliff
+
       - name: Compute release tag
         id: compute_release_version
         run: |


### PR DESCRIPTION
## Summary
  - Install `git-cliff` in the release workflow before computing the next tag.