### PR TITLE
fix(release): mark repository safe for git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,10 @@ jobs:
           ref: ${{ needs.release.outputs.next_tag }}
           fetch-depth: 1
 
+      - name: Mark repository as safe for git
+        shell: sh
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Cache Go modules and build outputs
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
  ## Summary
  - Mark the release workflow repository as a safe Git directory before the Linux native build step.